### PR TITLE
Update wasmerjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -998,9 +998,9 @@
       "dev": true
     },
     "@wasmer/wasi": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@wasmer/wasi/-/wasi-0.4.5.tgz",
-      "integrity": "sha512-dOt+Zj6vOk1C+1O+6aduKQgCy5VHZE20d14stGOFY0qPptJB8f4tfLWvd/NY/AK6hhSB8zFDV6rn1VowdiqYdw==",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@wasmer/wasi/-/wasi-0.8.4.tgz",
+      "integrity": "sha512-ywn/o3i4dEtNgvtCcvqF4u5vlplouF09d7EFS5skQVi292jZe+hiajdzmw7wRCpB1QO7x8KpCqTd2/4uyUcL2w==",
       "requires": {
         "browser-process-hrtime": "^1.0.0",
         "buffer-es6": "^4.9.3",
@@ -1009,31 +1009,27 @@
       }
     },
     "@wasmer/wasm-transformer": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@wasmer/wasm-transformer/-/wasm-transformer-0.4.5.tgz",
-      "integrity": "sha512-GIOzar8FuO0yc6+tQA9qovOw0PO4btI2Gm+/gjQ1kVJEPaX4YHJAo8PtSoy+4NFmcoBIpY5ko7DC18zJrgxUqw=="
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@wasmer/wasm-transformer/-/wasm-transformer-0.8.4.tgz",
+      "integrity": "sha512-79edl+EcMlUgISTajW+UaUiC2yAHmIi/vnoXGu9zipMOrIEFB4G7hifXEKVDEQGe33iQsI2g5pq2ebnsNdwG5w==",
+      "requires": {
+        "wasm-feature-detect": "^1.2.2"
+      }
     },
     "@wasmer/wasmfs": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@wasmer/wasmfs/-/wasmfs-0.4.5.tgz",
-      "integrity": "sha512-rsUQ/BP4T+TGBhQbZ97QVwSNFsPPeSIy2PYhfae4mwPjNPqqh1s117QpoybuTRUV5oOWGQX5JiG5JqVEcaUlcw==",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@wasmer/wasmfs/-/wasmfs-0.8.4.tgz",
+      "integrity": "sha512-+NmULGq2k/qvjp54AfjvfE14j65AVQXpzGXqP2yDWHAy7PC5hFB3nBgB32ymR0JAmDPYgyLY1oG5xRnUqRukng==",
       "requires": {
-        "memfs": "git+https://github.com/torch2424/memfs.git#wasmfs-fixes"
+        "memfs": "^3.0.4",
+        "pako": "^1.0.11",
+        "tar-stream": "^2.1.0"
       },
       "dependencies": {
-        "fast-extend": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/fast-extend/-/fast-extend-0.0.2.tgz",
-          "integrity": "sha1-9exCz0C5Rg9SGmOH37Ut7u1nHb0="
-        },
-        "memfs": {
-          "version": "git+https://github.com/torch2424/memfs.git#50997b4374121eb30e4e571a311e3effe824ea82",
-          "from": "git+https://github.com/torch2424/memfs.git#wasmfs-fixes",
-          "requires": {
-            "browser-assert": "^1.2.1",
-            "fast-extend": "0.0.2",
-            "fs-monkey": "^0.3.3"
-          }
+        "pako": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+          "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
         }
       }
     },
@@ -1506,6 +1502,26 @@
       "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE=",
       "dev": true
     },
+    "bl": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
+      "integrity": "sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==",
+      "requires": {
+        "readable-stream": "^3.0.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
     "bn.js": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
@@ -1545,11 +1561,6 @@
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
-    },
-    "browser-assert": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/browser-assert/-/browser-assert-1.2.1.tgz",
-      "integrity": "sha1-mqpaKox0aFwq4Fv+Ru/WBvBowgA="
     },
     "browser-process-hrtime": {
       "version": "1.0.0",
@@ -2753,6 +2764,14 @@
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
     },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
     "entities": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
@@ -3130,6 +3149,11 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true
+    },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "fs-monkey": {
       "version": "0.3.3",
@@ -5052,7 +5076,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -6979,7 +7002,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       },
@@ -6987,8 +7009,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
       }
     },
@@ -7059,6 +7080,30 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
+    },
+    "tar-stream": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.0.tgz",
+      "integrity": "sha512-+DAn4Nb4+gz6WZigRzKEZl1QuJVOLtAwwF+WUxy1fJ6X63CaGaUAxJRD2KEn1OMfcbCjySTYpNC6WmfQoIEOdw==",
+      "requires": {
+        "bl": "^3.0.0",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "terser": {
       "version": "3.17.0",
@@ -7456,8 +7501,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "util.promisify": {
       "version": "1.0.0",
@@ -7538,6 +7582,11 @@
         "xml-name-validator": "^3.0.0"
       }
     },
+    "wasm-feature-detect": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.2.2.tgz",
+      "integrity": "sha512-fj8PiWfNux69j27u9wQgPzltip7WioDMjldbVb6JFvb2PnF2JvKN/PfFOkrhbg4RQo/+Q8ClcZI6vJMOCSQz+Q=="
+    },
     "wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -7597,8 +7646,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
       "version": "6.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -998,9 +998,9 @@
       "dev": true
     },
     "@wasmer/wasi": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@wasmer/wasi/-/wasi-0.8.4.tgz",
-      "integrity": "sha512-ywn/o3i4dEtNgvtCcvqF4u5vlplouF09d7EFS5skQVi292jZe+hiajdzmw7wRCpB1QO7x8KpCqTd2/4uyUcL2w==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@wasmer/wasi/-/wasi-0.10.0.tgz",
+      "integrity": "sha512-9toRqlH9QZDVdAn7xv3cPw/Jkl/agYyqY4TuxcEC0B9TgmuvGI0yj3TNMwbbULMm3Yi8Jla/ErpLTLkhnlhGqQ==",
       "requires": {
         "browser-process-hrtime": "^1.0.0",
         "buffer-es6": "^4.9.3",
@@ -1009,19 +1009,19 @@
       }
     },
     "@wasmer/wasm-transformer": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@wasmer/wasm-transformer/-/wasm-transformer-0.8.4.tgz",
-      "integrity": "sha512-79edl+EcMlUgISTajW+UaUiC2yAHmIi/vnoXGu9zipMOrIEFB4G7hifXEKVDEQGe33iQsI2g5pq2ebnsNdwG5w==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@wasmer/wasm-transformer/-/wasm-transformer-0.10.0.tgz",
+      "integrity": "sha512-y0askaNhJUklqATadEA7665skxcKu5/9m7tz60eGWbPIt6Lky1j7t3A7xmC4LnERHM3i+GrSn8egEgrWXDCFbg==",
       "requires": {
         "wasm-feature-detect": "^1.2.2"
       }
     },
     "@wasmer/wasmfs": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@wasmer/wasmfs/-/wasmfs-0.8.4.tgz",
-      "integrity": "sha512-+NmULGq2k/qvjp54AfjvfE14j65AVQXpzGXqP2yDWHAy7PC5hFB3nBgB32ymR0JAmDPYgyLY1oG5xRnUqRukng==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@wasmer/wasmfs/-/wasmfs-0.10.0.tgz",
+      "integrity": "sha512-VdMLE9PV7Yws0M3j3PWr482Q602FzH8FChz366cb2cPFCEzAgHpPIsmaUCq9qn6MbST2oFhkB/sLeUM/DxQMxw==",
       "requires": {
-        "memfs": "^3.0.4",
+        "memfs": "3.0.4",
         "pako": "^1.0.11",
         "tar-stream": "^2.1.0"
       },
@@ -1503,11 +1503,11 @@
       "dev": true
     },
     "bl": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
-      "integrity": "sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.1.tgz",
+      "integrity": "sha512-FL/TdvchukRCuWVxT0YMO/7+L5TNeNrVFvRU2IY63aUyv9mpt8splf2NEr6qXtPo5fya5a66YohQKvGNmLrWNA==",
       "requires": {
-        "readable-stream": "^3.0.1"
+        "readable-stream": "^3.4.0"
       },
       "dependencies": {
         "readable-stream": {
@@ -5496,9 +5496,9 @@
       "dev": true
     },
     "path-browserify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.0.tgz",
-      "integrity": "sha512-Hkavx/nY4/plImrZPHRk2CL9vpOymZLgEbMNX1U0bjcBL7QN9wODxyx0yaMZURSQaUtSEvDrfAvxa9oPb0at9g=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
     },
     "path-dirname": {
       "version": "1.0.2",
@@ -7082,11 +7082,11 @@
       "dev": true
     },
     "tar-stream": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.0.tgz",
-      "integrity": "sha512-+DAn4Nb4+gz6WZigRzKEZl1QuJVOLtAwwF+WUxy1fJ6X63CaGaUAxJRD2KEn1OMfcbCjySTYpNC6WmfQoIEOdw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.1.tgz",
+      "integrity": "sha512-GZjLk64XcE/58qwIc1ZfXGqTSE4OutPMEkfBE/oh9eJ4x1eMRjYkgrLrav7PzddpvIpSJSGi8FgNNYXdB9Vumg==",
       "requires": {
-        "bl": "^3.0.0",
+        "bl": "^4.0.1",
         "end-of-stream": "^1.4.1",
         "fs-constants": "^1.0.0",
         "inherits": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -10,12 +10,11 @@
   },
   "dependencies": {
     "@babel/preset-env": "^7.6.3",
-    "@wasmer/wasi": "^0.4.5",
-    "@wasmer/wasm-transformer": "^0.4.5",
-    "@wasmer/wasmfs": "^0.4.5",
+    "@wasmer/wasi": "^0.10.0",
+    "@wasmer/wasm-transformer": "^0.10.0",
+    "@wasmer/wasmfs": "^0.10.0",
     "assert": "^2.0.0",
-    "buffer": "^5.4.3",
-    "memfs": "^3.0.4"
+    "buffer": "^5.4.3"
   },
   "devDependencies": {
     "@types/node": "^13.1.1",

--- a/src/kernel/exec.ts
+++ b/src/kernel/exec.ts
@@ -110,7 +110,8 @@ class ExecCore extends EventEmitter {
         // Fetch Wasm binary and instantiate WebAssembly instance
         var wamodule = await this.fetchCompile(wasmUri),
             wainstance = await WebAssembly.instantiate(wamodule, {
-                wasi_unstable: {...this.wasi.wasiImport, ...this.tty.overrideImport},
+                ...this.wasi.getImports(wamodule),
+                // wasi_unstable: {...this.tty.overrideImport},
                 wasi_ext: {...this.proc.extlib, ...this.tty.extlib},
                 env: {...this.proc.import, ...this.tty.import}
             });

--- a/src/wasmer-node.js
+++ b/src/wasmer-node.js
@@ -52,17 +52,6 @@ const wasi = new WASI({
   }
 });
 
-
-//console.log(wasi.wasiImport);
-
-// Make isatty(0) == 1
-wasi.FD_MAP.get(0).filetype = 2;
-wasi.FD_MAP.get(0).rights.base &= ~BigInt(0x24);
-// Make isatty(1) == 1
-wasi.FD_MAP.get(1).filetype = 2;
-wasi.FD_MAP.get(1).rights.base &= ~BigInt(0x24);
-
-
 // Read in the input Wasm file
 const wasmBuffer = fs.readFileSync('busy-wasi.wasm');
 


### PR DESCRIPTION
The latest version of Wasmer-JS WASI, has full support for `isatty`.

It also improved the way you use imports, so future versions of WASI are supported